### PR TITLE
Add PDF Dual Insert plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18422,5 +18422,12 @@
     "author": "Pavel Sokolov",
     "description": "Display Yandex Tracker issues in your notes",
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
+  },
+  {
+    "id": "pdf-dual-insert",
+    "name": "PDF Dual Insert",
+    "author": "mioupa",
+    "description": "Automatically insert both a clickable link and an embedded preview when dragging and dropping PDFs into the editor.",
+    "repo": "mioupa/pdf-dual-insert"
   }
 ]


### PR DESCRIPTION
Adds "PDF Dual Insert" plugin.
- Inserts both a clickable link and an embedded preview when dropping PDFs
- Works for internal and external drag & drop
- Configurable link label and link style (Markdown / WikiLink)
